### PR TITLE
Solvedac update

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -28,6 +28,10 @@ servers:
 tags:
   - name: "account"
     description: "계정과 관련이 있는 API입니다"
+  - name: "badge"
+    description: "뱃지와 관련이 있는 API입니다"
+  - name: "background"
+    description: "배경과 관련이 있는 API입니다"
   - name: "coins"
     description: "코인/별조각과 관련이 있는 API입니다"
   - name: "other"
@@ -46,6 +50,10 @@ paths:
     $ref: "./paths/account/update_settings.yaml#/paths/Path"
   /account/verify_credentials:
     $ref: "./paths/account/verify_credentials.yaml#/paths/Path"
+  /background/show:
+    $ref: "./paths/background/show.yaml#/paths/Path"
+  /badge/show:
+    $ref: "./paths/badge/show.yaml#/paths/Path"
   /coins/exchange_rate:
     $ref: "./paths/coins/exchange_rate.yaml#/paths/Path"
   /coins/shop/list:
@@ -128,8 +136,14 @@ components:
       $ref: "./schemas/class-decoration.yaml#/components/schemas/ClassDecoration"
     CoinshopProduct:
       $ref: "./schemas/coinshop-product.yaml#/components/schemas/CoinshopProduct"
+    Background:
+      $ref: "./schemas/background.yaml#/components/schemas/Background"
     Badge:
       $ref: "./schemas/badge.yaml#/components/schemas/Badge"
+    BadgeCategory:
+      $ref: "./schemas/badge-category.yaml#/components/schemas/BadgeCategory"
+    BadgeTier:
+      $ref: "./schemas/badge-tier.yaml#/components/schemas/BadgeTier"
     FullUser:
       $ref: "./schemas/full-user.yaml#/components/schemas/FullUser"
     IconScheme:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -106,6 +106,8 @@ paths:
       responses:
         "200":
           description: "TODO"
+  /user/organizations:
+    $ref: "./paths/user/organizations.yaml#/paths/Path"
   /user/problem_stats:
     $ref: "./paths/user/problem_stats.yaml#/paths/Path"
   /user/problem_tag_stats:

--- a/src/paths/background/show.yaml
+++ b/src/paths/background/show.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+paths:
+  Path:
+    get:
+      summary: "배경 정보 가져오기"
+      description: "배경의 정보를 가져옵니다."
+      tags:
+        - background
+      operationId: getBackground
+
+      parameters:
+        - name: "backgroundId"
+          in: "query"
+          description: "배경 ID"
+          required: true
+          schema:
+            type: "string"
+
+      responses:
+        "200":
+          description: "서버가 반환에 성공한 경우입니다."
+          content:
+            application/json:
+              schema:
+                $ref: "../../schemas/background.yaml#/components/schemas/Background"

--- a/src/paths/badge/show.yaml
+++ b/src/paths/badge/show.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+paths:
+  Path:
+    get:
+      summary: "뱃지 정보 가져오기"
+      description: "뱃지의 정보를 가져옵니다."
+      tags:
+        - badge
+      operationId: getBadge
+
+      parameters:
+        - name: "badgeId"
+          in: "query"
+          description: "뱃지 ID"
+          required: true
+          schema:
+            type: "string"
+
+      responses:
+        "200":
+          description: "서버가 반환에 성공한 경우입니다."
+          content:
+            application/json:
+              schema:
+                $ref: "../../schemas/badge.yaml#/components/schemas/Badge"

--- a/src/paths/user/organizations.yaml
+++ b/src/paths/user/organizations.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+paths:
+  Path:
+    get:
+      summary: "사용자가 속한 조직 목록 가져오기"
+      description: "사용자가 속한 조직 목록를 가져옵니다."
+      tags:
+        - user
+      operationId: getUserOrganizations
+
+      security:
+        - {}
+        - solvedacToken: []
+
+      parameters:
+        - name: "handle"
+          in: "query"
+          description: "사용자 ID"
+          required: true
+          schema:
+            type: "string"
+
+      responses:
+        "200":
+          description: "서버가 반환에 성공한 경우입니다."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  type: "object"
+                  $ref: "../../schemas/organization.yaml#/components/schemas/Organization"

--- a/src/schemas/background.yaml
+++ b/src/schemas/background.yaml
@@ -70,7 +70,6 @@ components:
           type: "array"
           items:
             type: "object"
-            example: [ { "authorId": "havana723","role": "Illustration","authorUrl": null,"handle": "havana723","twitter": null,"instagram": null,"displayName": "havana723" } ]
             properties:
               authorId:
                 description: "작가의 ID입니다."

--- a/src/schemas/background.yaml
+++ b/src/schemas/background.yaml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+components:
+  schemas:
+    Background:
+      title: Background
+      description: |
+        사용자가 사용할 수 있는 배경입니다.
+      type: "object"
+      required:
+        - backgroundId
+        - backgroundImageUrl
+        - unlockedUserCount
+        - displayName
+        - displayDescription
+        - conditions
+        - hiddenConditions
+        - isIllust
+        - authors
+      properties:
+        backgroundId:
+          description: "배경의 ID입니다."
+          type: "string"
+          example: "hanbyeol_stars"
+        backgroundImageUrl:
+          description: "배경 사진으로 가는 하이퍼링크입니다."
+          type: "string"
+          example: "https://static.solved.ac/profile_bg/hanbyeol_stars/hanbyeol_stars.jpg"
+        fallbackBackgroundImageUrl:
+          description: "배경 사진이 없을 때 대체로 사용할 사진으로 가는 하이퍼링크입니다."
+          type: "string"
+          nullable: true
+          example: null
+        backgroundVideoUrl:
+          description: "배경 비디오로 가는 하이퍼링크입니다."
+          type: "string"
+          nullable: true
+          example: null
+        unlockedUserCount:
+          description: "해당 배경을 획득한 사용자의 수입니다."
+          type: "integer"
+          format: "int64"
+          example: 1394
+        displayName:
+          description: "배경의 이름입니다."
+          type: "string"
+          example: "Stars in the Evening Sky"
+        displayDescription:
+          description: "배경의 설명입니다."
+          type: "string"
+          example: "She who has a star in her heart never gets lost in the dark"
+        conditions:
+          description: "해당 배경을 얻을 수 있는 조건입니다."
+          type: "string"
+          example: "Bought the background at the coin shop"
+        hiddenConditions:
+          description: "해당 배경을 얻을 수 있는 조건이 숨겨져 있는지 여부입니다."
+          type: "boolean"
+          example: false
+        isIllust:
+          description: "해당 배경이 일러스트인지 여부입니다."
+          type: "boolean"
+          example: true
+        authors:
+          description: "해당 배경을 만든 사람들의 정보입니다."
+          type: "array"
+          items:
+            type: "object"
+            example: [ { "authorId": "havana723","role": "Illustration","authorUrl": null,"handle": "havana723","twitter": null,"instagram": null,"displayName": "havana723" } ]
+            properties:
+              authorId:
+                description: "작가의 ID입니다."
+                type: "string"
+                example: "havana723"
+              role:
+                description: "작가의 역할입니다."
+                type: "string"
+                example: "Illustration"
+              authorUrl:
+                description: "작가의 홈페이지로 가는 하이퍼링크입니다."
+                type: "string"
+                nullable: true
+                example: null
+              handle:
+                description: "작가의 사용자 ID입니다."
+                type: "string"
+                example: "havana723"
+              twitter:
+                description: "작가의 트위터 ID입니다."
+                type: "string"
+                nullable: true
+                example: null
+              instagram:
+                description: "작가의 인스타그램 ID입니다."
+                type: "string"
+                nullable: true
+                example: null
+              displayName:
+                description: "작가의 이름입니다."
+                type: "string"
+                example: "havana723"

--- a/src/schemas/badge-category.yaml
+++ b/src/schemas/badge-category.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+components:
+  schemas:
+    BadgeCategory:
+      title: BadgeCategory
+      type: "string"
+      enum:
+        - "achievement"
+        - "season"
+        - "event"
+        - "contest"
+      description: |
+        뱃지 종류입니다.

--- a/src/schemas/badge-tier.yaml
+++ b/src/schemas/badge-tier.yaml
@@ -15,4 +15,4 @@ components:
         - "gold"
         - "master"
       description: |
-        뱃지 치장입니다.
+        뱃지 티어입니다.

--- a/src/schemas/badge-tier.yaml
+++ b/src/schemas/badge-tier.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://spec.openapis.org/oas/3.1/schema/2021-05-20
+---
+# for the intellisense
+openapi: "3.1.0"
+info: { title: "", version: "" }
+
+components:
+  schemas:
+    BadgeTier:
+      title: BadgeTier
+      type: "string"
+      enum:
+        - "bronze"
+        - "silver"
+        - "gold"
+        - "master"
+      description: |
+        뱃지 치장입니다.

--- a/src/schemas/badge.yaml
+++ b/src/schemas/badge.yaml
@@ -35,15 +35,7 @@ components:
           example: "solved.ac의 1주년과 함께했다"
         badgeTier:
           type: "string"
-          enum:
-            - "bronze"
-            - "silver"
-            - "gold"
-            - "master"
+          $ref: "./badge-tier.yaml#/components/schemas/BadgeTier"
         badgeCategory:
           type: "string"
-          enum:
-            - "achievement"
-            - "season"
-            - "event"
-            - "contest"
+          $ref: "./badge-category.yaml#/components/schemas/BadgeCategory"

--- a/src/schemas/badge.yaml
+++ b/src/schemas/badge.yaml
@@ -33,3 +33,17 @@ components:
           description: "뱃지의 설명입니다."
           type: "string"
           example: "solved.ac의 1주년과 함께했다"
+        badgeTier:
+          type: "string"
+          enum:
+            - "bronze"
+            - "silver"
+            - "gold"
+            - "master"
+        badgeCategory:
+          type: "string"
+          enum:
+            - "achievement"
+            - "season"
+            - "event"
+            - "contest"

--- a/src/schemas/full-user.yaml
+++ b/src/schemas/full-user.yaml
@@ -14,10 +14,6 @@ components:
         - $ref: "./user.yaml#/components/schemas/User"
         - type: "object"
           properties:
-            rank:
-              description: "사용자의 순위입니다."
-              type: "integer"
-              format: "int64"
             isRival:
               description: "라이벌 여부입니다."
               type: "boolean"

--- a/src/schemas/user.yaml
+++ b/src/schemas/user.yaml
@@ -15,7 +15,7 @@ components:
         - handle
         - bio
         - organizations
-        - background
+        - backgroundId
         - profileImageUrl
         - solvedCount
         - voteCount
@@ -31,6 +31,12 @@ components:
         - rivalCount
         - reverseRivalCount
         - maxStreak
+        - coins
+        - stardusts
+        - joinedAt
+        - bannedUntil
+        - proUntil
+        - rank
       properties:
         handle:
           description: "사용자명입니다."
@@ -40,42 +46,13 @@ components:
           description: "사용자의 자기소개입니다."
           type: "string"
           example: "🧡 이곳의 개발자입니다."
-        organizations:
-          description: "사용자가 속한 조직 목록입니다."
-          type: "array"
-          items:
-            $ref: "./organization.yaml#/components/schemas/Organization"
-        badge:
-          description: "사용자가 지금 사용 중인 뱃지입니다."
-          $ref: "./badge.yaml#/components/schemas/Badge"
-        background:
-          description: "사용자의 배경 사진입니다."
-          type: "object"
-          properties:
-            backgroundId:
-              description: "배경의 고유 ID입니다."
-              type: "string"
-              example: "balloon_002"
-            backgroundImageUrl:
-              description: "배경 사진으로 가는 하이퍼링크입니다."
-              type: "string"
-              example: "https://static.solved.ac/profile_bg/balloon_002/balloon_002.png"
-            author:
-              description: "배경의 제작자를 표시하는 문구입니다."
-              type: "string"
-              example: "Photo by Al Soot on Unsplash"
-            authorUrl:
-              description: "배경의 제작자와 관련된 사이트로 가는 하이퍼링크입니다."
-              type: "string"
-              example: "https://unsplash.com/photos/yRjLihK35Yw"
-            displayName:
-              description: "배경의 이름입니다."
-              type: "string"
-              example: "하늘을 수놓은 풍선"
-            displayDescription:
-              description: "배경의 설명입니다."
-              type: "string"
-              example: "assorted colored balloons mid airs"
+        badgeId:
+          description: "사용자가 지금 사용 중인 뱃지의 아이디입니다."
+          type: "string"
+          nullable: true
+        backgroundId:
+            description: "사용자가 지금 사용 중인 배경의 아이디입니다."
+            type: "string"
         profileImageUrl:
           description: "사용자의 프로필 사진으로 가는 하이퍼링크입니다."
           type: "string"
@@ -146,3 +123,33 @@ components:
           type: "integer"
           format: "int64"
           example: 6
+        coins:
+          description: "사용자가 가지고 있는 코인의 수입니다."
+          type: "integer"
+          format: "int64"
+          example: 3845
+        stardusts:
+          description: "사용자가 가지고 있는 별가루의 수입니다."
+          type: "integer"
+          format: "int64"
+          example: 264680
+        joinedAt:
+          description: "사용자가 가입한 날짜입니다."
+          type: "string"
+          format: "date-time"
+          example: "2021-06-19T00:00:00.000Z"
+        bannedUntil:
+          description: "사용자의 정지 종료 날짜입니다."
+          type: "string"
+          format: "date-time"
+          example: "1970-01-01T00:00:00.000Z"
+        proUntil:
+          description: "사용자의 PRO 종료 날짜입니다."
+          type: "string"
+          format: "date-time"
+          example: "9999-12-31T00:00:00.000Z"
+        rank:
+          description: "사용자의 순위입니다."
+          type: "integer"
+          format: "int64"
+          example: 104

--- a/src/schemas/user.yaml
+++ b/src/schemas/user.yaml
@@ -50,9 +50,11 @@ components:
           description: "사용자가 지금 사용 중인 뱃지의 아이디입니다."
           type: "string"
           nullable: true
+          example: "ghudegy2022-1"
         backgroundId:
-            description: "사용자가 지금 사용 중인 배경의 아이디입니다."
-            type: "string"
+          description: "사용자가 지금 사용 중인 배경의 아이디입니다."
+          type: "string"
+          example: "boardgame_7"
         profileImageUrl:
           description: "사용자의 프로필 사진으로 가는 하이퍼링크입니다."
           type: "string"


### PR DESCRIPTION
#52 23/03/13 일자 solvedac 백엔드 업데이트에 따른 api 명세 변경입니다. 

- [x] /user/show 변경
- [x] /user/organization 추가
- [x] /badge/show 추가
- [x] /background/show 추가

## /user/show 변경
  - `organizations`, `badge`, `background` 제거
  - `badgeId`, `backgroundId`, `coins`, `stardusts`, `joinedAt`, `bannedUntil`, `proUntil` 추가
  - `rank` full-user에서 이동

![image](https://user-images.githubusercontent.com/52066828/226107125-10990ec5-c406-4234-b71e-db8f1ed0d22d.png)

## /user/organizations 추가
  - `Organization` 객체 Array 반환

![image](https://user-images.githubusercontent.com/52066828/226107158-bbf8a26d-d4e4-4f0b-bc74-e5a13f3ca7f1.png)


##  /badge/show /background/show 추가
- 엔드포인트 추가

![image](https://user-images.githubusercontent.com/52066828/226107182-60f0b9c6-e388-4ee8-8a00-36d0f0e1aa66.png)    

- Badge 객체에 `badgeTier`, `badgeCategory` 추가 및 각 스키마 생성

![image](https://user-images.githubusercontent.com/52066828/226107192-7f8701a9-5b9a-41a4-8306-7dad88e6f89f.png)    

- Background 객체 및 스키마 생성

![image](https://user-images.githubusercontent.com/52066828/226107201-3691b384-5d6c-4afe-9c65-35b3e24caaf6.png)
