### PR TITLE
/problem/class 수정

### DIFF
--- a/src/paths/problem/class.yaml
+++ b/src/paths/problem/class.yaml
@@ -33,10 +33,16 @@ paths:
                       format: "int64"
                       minimum: 0
                       description: "이 CLASS에 속한 에센셜이 아닌 문제 수입니다."
-                      example: 24
-                    essential:
+                      example: 36
+                    essentials:
                       type: "integer"
                       format: "in64"
                       minimum: 0
                       description: "이 CLASS에 속한 에센셜 문제 수입니다."
-                      example: 20
+                      example: 16
+                    criteria:
+                      type: "integer"
+                      format: "in64"
+                      minimum: 0
+                      description: "이 CLASS를 취득하기 위한 최소 문제 수입니다."
+                      example: 16


### PR DESCRIPTION
/problem/class API의 반환값이

 ```
[
  {
    "class": 1,
    "total": 36,
    "essentials": 16,
    "criteria": 16
  },
  {
    "class": 2,
    "total": 40,
    "essentials": 20,
    "criteria": 16
  },

...
```

처럼 바뀌었습니다.

`essential` -> `essentials` 로 수정
`criteria` 추가 - 클래스 취득 최소 문제 수



response example 값을 class: 1, total: 36, essentials: 16, criteria: 16 로 수정했습니다.