### PR TITLE
잘못된 설명 수정

### DIFF
--- a/src/operations/coins/exchange_rate.tsp
+++ b/src/operations/coins/exchange_rate.tsp
@@ -4,7 +4,7 @@ using TypeSpec.OpenAPI;
 namespace SolvedAC;
 
 /**
- * 주어진 쿼리에 따라 문제를 검색합니다.
+ * 코인 → 별조각 환율을 가져옵니다.
  *
  * @return
  *     환율을 가져옵니다.


### PR DESCRIPTION
"코인 → 별조각 환율 가져오기"의 설명을 "주어진 쿼리에 따라 문제를 검색합니다."에서 "코인 → 별조각 환율을 가져옵니다."으로 수정했습니다.